### PR TITLE
Update modules to fix npm audit warning, handle remote url (vs. host), error handling

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2,21 +2,22 @@
   "name": "tunnel.now",
   "version": "1.2.0",
   "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "ansi-regex": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
     },
-    "builtin-modules": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
-      "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
+    "async-limiter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
+      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg=="
     },
     "bytes": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
-      "integrity": "sha1-fZcZb51br39pNeJZhVSe3SpsIzk="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
     "camelcase": {
       "version": "4.1.0",
@@ -29,15 +30,13 @@
       "integrity": "sha512-U9B925/rt57EfPKINS42BT1/fzHjWQo42YBNRwFbHzKQjrSVYDn+S0kl/LY9TH0d1ZCzioyAmuV3lV9rsNO2BA=="
     },
     "cliui": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-      "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-      "dependencies": {
-        "string-width": {
-          "version": "1.0.2",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M="
-        }
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-4.1.0.tgz",
+      "integrity": "sha512-4FG+RSG9DL7uEwRUZXZn3SS34DiDPfzP0VOiEwtUWlE+AR2EIg+hSyvrIgUUfhdgR/UkAeW2QHgeP+hWrXs7jQ==",
+      "requires": {
+        "string-width": "^2.1.1",
+        "strip-ansi": "^4.0.0",
+        "wrap-ansi": "^2.0.0"
       }
     },
     "code-point-at": {
@@ -46,79 +45,95 @@
       "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
     },
     "cross-spawn": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
-      "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk="
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "requires": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
     },
     "decamelize": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-2.0.0.tgz",
+      "integrity": "sha512-Ikpp5scV3MSYxY39ymh45ZLEecsTdv/Xj2CaQfI8RLMuwi7XvjX9H/fhraiSuU+C5w5NTDu4ZU72xNiZnurBPg==",
+      "requires": {
+        "xregexp": "4.0.0"
+      }
     },
-    "encoding": {
-      "version": "0.1.12",
-      "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
-      "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s="
-    },
-    "error-ex": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw="
+    "depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
     "execa": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
-      "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c="
+      "version": "0.10.0",
+      "resolved": "https://registry.npmjs.org/execa/-/execa-0.10.0.tgz",
+      "integrity": "sha512-7XOMnz8Ynx1gGo/3hyV9loYNPWM94jG3+3T3Y8tsfSstFmETmENCMU/A/zj8Lyaj1lkgEepKepvd6240tBRvlw==",
+      "requires": {
+        "cross-spawn": "^6.0.0",
+        "get-stream": "^3.0.0",
+        "is-stream": "^1.1.0",
+        "npm-run-path": "^2.0.0",
+        "p-finally": "^1.0.0",
+        "signal-exit": "^3.0.0",
+        "strip-eof": "^1.0.0"
+      }
     },
     "find-up": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
-      "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
+      "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
+      "requires": {
+        "locate-path": "^3.0.0"
+      }
     },
     "get-caller-file": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.2.tgz",
-      "integrity": "sha1-9wLmMSfn4jHBYKgMFVSstw1QR+U="
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-1.0.3.tgz",
+      "integrity": "sha512-3t6rVToeoZfYSGd8YoLFR2DJkiQrIiUrGcjvFX2mDw3bn6k2OtwHN0TNCLbBO+w8qTvimhDkv+LSscbJY1vE6w=="
     },
     "get-stream": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
       "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
     },
-    "graceful-fs": {
-      "version": "4.1.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
-      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
-    },
-    "hosted-git-info": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.4.2.tgz",
-      "integrity": "sha1-AHa59GonBQbduq6lZJaJdGBhKmc="
+    "http-errors": {
+      "version": "1.6.3",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+      "requires": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.0",
+        "statuses": ">= 1.4.0 < 2"
+      }
     },
     "iconv-lite": {
-      "version": "0.4.17",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.17.tgz",
-      "integrity": "sha1-T9qjs4rLwsAxsEXQ7c3+HsqxjI0="
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "invert-kv": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
       "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY="
     },
-    "is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
-    },
-    "is-builtin-module": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
-      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74="
-    },
     "is-fullwidth-code-point": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
     },
     "is-stream": {
       "version": "1.1.0",
@@ -133,77 +148,98 @@
     "lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU="
-    },
-    "load-json-file": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-      "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg="
+      "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+      "requires": {
+        "invert-kv": "^1.0.0"
+      }
     },
     "locate-path": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
-      "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
+      "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
+      "requires": {
+        "p-locate": "^3.0.0",
+        "path-exists": "^3.0.0"
+      }
     },
     "lru-cache": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.0.tgz",
-      "integrity": "sha512-aHGs865JXz6bkB4AHL+3AhyvTFKL3iZamKVWjIUKnXOXyasJvqPK8WAjOnAQKQZVpeXDVz19u1DD0r/12bWAdQ=="
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
     },
     "mem": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
-      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y="
+      "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
+      "requires": {
+        "mimic-fn": "^1.0.0"
+      }
     },
     "mimic-fn": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz",
-      "integrity": "sha1-5md4PZLonb00KBi1IwudYqZyrRg="
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ=="
+    },
+    "nice-try": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.4.tgz",
+      "integrity": "sha512-2NpiFHqC87y/zFke0fC0spBXL3bBsoh/p5H1EFhshxjCR5+0g2d6BiXbUFz9v1sAcxsk2htp2eQnNIci2dIYcA=="
     },
     "node-fetch": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.1.tgz",
-      "integrity": "sha512-j8XsFGCLw79vWXkZtMSmmLaOk9z5SQ9bV/tkbZVCqvgwzrjAGq66igobLofHtF63NvMTp2WjytpsNTGKa+XRIQ=="
-    },
-    "normalize-package-data": {
-      "version": "2.3.8",
-      "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.8.tgz",
-      "integrity": "sha1-2Bntoqne29H/pWPqQHHZNngilbs="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.2.0.tgz",
+      "integrity": "sha512-OayFWziIxiHY8bCUyLX6sTpDH8Jsbp4FfYd1j1f7vZyfgkcOnAyM4oQR16f8a0s7Gl/viMGRey8eScYk4V4EZA=="
     },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
-      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8="
+      "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+      "requires": {
+        "path-key": "^2.0.0"
+      }
     },
     "number-is-nan": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
       "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
     },
-    "object-assign": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
-    },
     "os-locale": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.0.0.tgz",
-      "integrity": "sha1-FZGN7VEFIrge565aMJ1U9jn8OaQ=",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
+      "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
+      "requires": {
+        "execa": "^0.7.0",
+        "lcid": "^1.0.0",
+        "mem": "^1.1.0"
+      },
       "dependencies": {
         "cross-spawn": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-4.0.2.tgz",
-          "integrity": "sha1-e5JHYhwjrf3ThWAEqCPL45dCTUE="
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
+          "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
+          "requires": {
+            "lru-cache": "^4.0.1",
+            "shebang-command": "^1.2.0",
+            "which": "^1.2.9"
+          }
         },
         "execa": {
-          "version": "0.5.1",
-          "resolved": "https://registry.npmjs.org/execa/-/execa-0.5.1.tgz",
-          "integrity": "sha1-3j+4XLjW6RyFvLzrFkWBeFy1ezY="
-        },
-        "get-stream": {
-          "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-2.3.1.tgz",
-          "integrity": "sha1-Xzj5PzRgCWZu4BUKBUFn+Rvdld4="
+          "version": "0.7.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
+          "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
+          "requires": {
+            "cross-spawn": "^5.0.1",
+            "get-stream": "^3.0.0",
+            "is-stream": "^1.1.0",
+            "npm-run-path": "^2.0.0",
+            "p-finally": "^1.0.0",
+            "signal-exit": "^3.0.0",
+            "strip-eof": "^1.0.0"
+          }
         }
       }
     },
@@ -213,19 +249,25 @@
       "integrity": "sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4="
     },
     "p-limit": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.1.0.tgz",
-      "integrity": "sha1-sH/y2aXYi+yAYDWJWiurZqJ5iLw="
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.0.0.tgz",
+      "integrity": "sha512-fl5s52lI5ahKCernzzIyAP0QAZbGIovtVHGwpcu1Jr/EpzLVDI2myISHwGqK7m8uQFugVWSrbxH7XnhGtvEc+A==",
+      "requires": {
+        "p-try": "^2.0.0"
+      }
     },
     "p-locate": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
-      "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
+      "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
+      "requires": {
+        "p-limit": "^2.0.0"
+      }
     },
-    "parse-json": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-      "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck="
+    "p-try": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.0.0.tgz",
+      "integrity": "sha512-hMp0onDKIajHfIkdRk3P4CdCmErkYAxxDtP3Wx/4nZ3aGlau2VKh3mZpcuFkH27WQkL/3WBCPOktzA9ZOAnMQQ=="
     },
     "path-exists": {
       "version": "3.0.0",
@@ -237,52 +279,21 @@
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
       "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A="
     },
-    "path-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-      "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM="
-    },
-    "pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
-    },
-    "pinkie": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
-      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
-    },
-    "pinkie-promise": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o="
-    },
     "pseudomap": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "raw-body": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.2.0.tgz",
-      "integrity": "sha1-mUl2z2pQlqQRYoQEkvC9xdbn+5Y=",
-      "dependencies": {
-        "iconv-lite": {
-          "version": "0.4.15",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.15.tgz",
-          "integrity": "sha1-/iZaIYrGpXz+hUkn6dBMGYJe3es="
-        }
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.3.tgz",
+      "integrity": "sha512-9esiElv1BrZoI3rCDuOuKCBRbuApGGaDPQfjSflGxdy4oyzqghxu6klEkkVIvBje+FF0BX9coEv8KqW6X/7njw==",
+      "requires": {
+        "bytes": "3.0.0",
+        "http-errors": "1.6.3",
+        "iconv-lite": "0.4.23",
+        "unpipe": "1.0.0"
       }
-    },
-    "read-pkg": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-      "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg="
-    },
-    "read-pkg-up": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-      "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4="
     },
     "require-directory": {
       "version": "2.1.1",
@@ -294,25 +305,33 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
       "integrity": "sha1-l/cXtp1IeE9fUmpsWqj/3aBVpNE="
     },
-    "safe-buffer": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
-      "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
-      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha512-4SJ3dm0WAwWy/NVeioZh5AntkdJoWKxHxcmyP622fOkgHa4z3R0TdBJICINyaSDE6uNwVc8gZr+ZinwZAH4xIA=="
     },
     "set-blocking": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
       "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
     },
+    "setprototypeof": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "integrity": "sha512-BvE/TwpZX4FXExxOxZyRGQQv651MSwmWKZGqvmPcRIjDqWub67kTKuIMx43cZZrS/cBBzwBcNDWoFxt2XEFIpQ=="
+    },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
-      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo="
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
     },
     "shebang-regex": {
       "version": "1.0.0",
@@ -324,67 +343,45 @@
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
       "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
     },
-    "spdx-correct": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
-      "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A="
-    },
-    "spdx-expression-parse": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
-      "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
-    },
-    "spdx-license-ids": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
-      "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
+    "statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "string-width": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.0.0.tgz",
-      "integrity": "sha1-Y1xUNsxypuDDh87KJ41OLuxSaH4=",
-      "dependencies": {
-        "is-fullwidth-code-point": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-          "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8="
-        }
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
       }
     },
     "strip-ansi": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
-    },
-    "strip-bom": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-      "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "requires": {
+        "ansi-regex": "^3.0.0"
+      }
     },
     "strip-eof": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/strip-eof/-/strip-eof-1.0.0.tgz",
       "integrity": "sha1-u0P/VZim6wXYm1n80SnJgzE2Br8="
     },
-    "ultron": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.0.tgz",
-      "integrity": "sha1-sHoualQagV/Go0zNRTO67DB8qGQ="
-    },
     "unpipe": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
-    "validate-npm-package-license": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
-      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w="
-    },
     "which": {
-      "version": "1.2.14",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-      "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU="
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "requires": {
+        "isexe": "^2.0.0"
+      }
     },
     "which-module": {
       "version": "2.0.0",
@@ -395,23 +392,61 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
+      "requires": {
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1"
+      },
       "dependencies": {
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M="
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "requires": {
+            "code-point-at": "^1.0.0",
+            "is-fullwidth-code-point": "^1.0.0",
+            "strip-ansi": "^3.0.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "requires": {
+            "ansi-regex": "^2.0.0"
+          }
         }
       }
     },
     "ws": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-3.0.0.tgz",
-      "integrity": "sha1-mN2wAFbIOQy3Ued4h4hJf5kQO2w="
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.0.0.tgz",
+      "integrity": "sha512-c2UlYcAZp1VS8AORtpq6y4RJIkJ9dQz18W32SpR/qXGfLDZ2jU4y4wKvvZwqbi7U6gxFQTeE+urMbXU/tsDy4w==",
+      "requires": {
+        "async-limiter": "~1.0.0"
+      }
+    },
+    "xregexp": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/xregexp/-/xregexp-4.0.0.tgz",
+      "integrity": "sha512-PHyM+sQouu7xspQQwELlGwwd05mXUFqwFYfqPO0cC7x4fxyHnnuetmQr6CjJiafIDoH4MogHb9dOoJzR/Y4rFg=="
     },
     "y18n": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-      "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE="
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.0.tgz",
+      "integrity": "sha512-r9S/ZyXu/Xu9q1tYlpsLIsa3EeLXXk0VwlxqTcFRfg9EhMW+17kbt9G0NrgCmhGb5vT2hyhJZLfDGx+7+5Uj/w=="
     },
     "yallist": {
       "version": "2.1.2",
@@ -419,14 +454,31 @@
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yargs": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.1.tgz",
-      "integrity": "sha1-Qg73XoQMFFeoCtzKm8b6OEneUao="
+      "version": "12.0.1",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-12.0.1.tgz",
+      "integrity": "sha512-B0vRAp1hRX4jgIOWFtjfNjd9OA9RWYZ6tqGA9/I/IrTMsxmKvtWy+ersM+jzpQqbC3YfLzeABPdeTgcJ9eu1qQ==",
+      "requires": {
+        "cliui": "^4.0.0",
+        "decamelize": "^2.0.0",
+        "find-up": "^3.0.0",
+        "get-caller-file": "^1.0.1",
+        "os-locale": "^2.0.0",
+        "require-directory": "^2.1.1",
+        "require-main-filename": "^1.0.1",
+        "set-blocking": "^2.0.0",
+        "string-width": "^2.0.0",
+        "which-module": "^2.0.0",
+        "y18n": "^3.2.1 || ^4.0.0",
+        "yargs-parser": "^10.1.0"
+      }
     },
     "yargs-parser": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-      "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k="
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-10.1.0.tgz",
+      "integrity": "sha512-VCIyR1wJoEBZUqk5PA+oOBF6ypbwh5aNB3I50guxAL/quggdfs4TtNHQrSazFA3fYZ+tEqfs0zIGlv0c/rgjbQ==",
+      "requires": {
+        "camelcase": "^4.1.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,10 +30,10 @@
   "homepage": "https://github.com/divmain/tunnel.now#readme",
   "dependencies": {
     "cereal-box": "^1.0.0",
-    "execa": "^0.7.0",
-    "node-fetch": "^1.7.1",
-    "raw-body": "^2.2.0",
-    "ws": "^3.0.0",
-    "yargs": "^8.0.1"
+    "execa": "^0.10.0",
+    "node-fetch": "^2.2.0",
+    "raw-body": "^2.3.3",
+    "ws": "^6.0.0",
+    "yargs": "^12.0.1"
   }
 }

--- a/src/server.js
+++ b/src/server.js
@@ -24,6 +24,7 @@ const server = createServer((req, res) => {
   if (!activeConnection) {
     res.statusCode = 503;
     res.end("Tunneling client is not currently connected.");
+    return;
   }
 
   getRawBody(req).then(buffer => {
@@ -44,7 +45,7 @@ const handleResponse = message => {
   if (message === "PING") { return; }
   const { id, statusCode, headers, body } = decodeResponse(message);
   const res = responseRefs[id];
-  responseRefs[id] = null;
+  delete responseRefs[id];
 
   res.statusCode = statusCode;
   Object.keys(headers).forEach(key => res.setHeader(key, headers[key]));

--- a/src/server.js
+++ b/src/server.js
@@ -10,18 +10,22 @@ const {
 } = require("./codec");
 
 
-const { _: [ port = 8008 ] } = yargs
-  .usage('$0 [port]')
+const { _: [ port = 8008 ], debug } = yargs
+  .usage('$0 [--debug|-d] [port]')
+  .option('debug', {
+    alias: 'd',
+    default: false
+  })
   .help()
   .argv;
 
 
-let activeConnection = null;
+let client = null;
 let nextId = 0;
 
 const responseRefs = {};
 const server = createServer((req, res) => {
-  if (!activeConnection) {
+  if (!client) {
     res.statusCode = 503;
     res.end("Tunneling client is not currently connected.");
     return;
@@ -30,7 +34,7 @@ const server = createServer((req, res) => {
   getRawBody(req).then(buffer => {
     const id = nextId++;
     responseRefs[id] = res;
-    activeConnection.send(encodeRequest({
+    client.send(encodeRequest({
       id,
       url: req.url,
       method: req.method,
@@ -41,30 +45,57 @@ const server = createServer((req, res) => {
   });
 });
 
-const handleResponse = message => {
-  if (message === "PING") { return; }
-  const { id, statusCode, headers, body } = decodeResponse(message);
-  const res = responseRefs[id];
-  delete responseRefs[id];
+const wss = new WebSocket.Server({ server });
+wss.on("connection", (ws, req) => {
+  if (client) { ws.close("A client is already connected."); }
 
-  res.statusCode = statusCode;
-  Object.keys(headers).forEach(key => res.setHeader(key, headers[key]));
-  // Alternately, `Buffer.from(body.slice().buffer)`.
-  res.end(Buffer.from(body.buffer, body.byteOffset, body.length));
-};
-
-const wsServer = new WebSocket.Server({ server });
-wsServer.on("connection", (ws, req) => {
-  if (activeConnection) { ws.close("A client is already connected."); }
   const remoteIP = req.headers['x-forwarded-for'] || req.connection.remoteAddress;
   console.log(`Tunnel connected from $${remoteIP}.`);
-  activeConnection = ws;
-  ws.on("close", () => {
-    activeConnection = null;
+
+  client = ws;
+  client.alive = true;
+
+  client.on("close", () => {
+    client = null;
     console.log(`Tunnel disconnected from $${remoteIP}.`)
   });
-  ws.on("message", handleResponse);
+
+  client.on("message", message => {
+    const { id, statusCode, headers, body } = decodeResponse(message);
+    const res = responseRefs[id];
+    delete responseRefs[id];
+  
+    res.statusCode = statusCode;
+    Object.keys(headers).forEach(key => res.setHeader(key, headers[key]));
+    // Alternately, `Buffer.from(body.slice().buffer)`.
+    res.end(Buffer.from(body.buffer, body.byteOffset, body.length));
+  });
+
+  client.on("pong", () => {
+    if ( debug ) {
+      console.log( ' <- pong ' );
+    }
+    client.alive = true;
+  });
 });
+
+const interval = setInterval(() => {
+  if ( !client ) {
+    return;
+  }
+
+  if ( !client.alive ) {
+    client.terminate();
+    return;
+  }
+
+  client.alive = false;
+  client.ping(() => {
+    if ( debug ) {
+      console.log( ' ping -> ' );
+    }
+  });
+}, 30000);
 
 server.listen(port, () => {
   console.log(`Listening on port ${server.address().port}...`);

--- a/src/tunnel.js
+++ b/src/tunnel.js
@@ -71,7 +71,7 @@ ws.on("message", ev => {
     options.body = Buffer.from(body.buffer, body.byteOffset, body.length);
   }
 
-  fetch(`${baseTargetUrl}${url}`, ).then(response => {
+  fetch(`${baseTargetUrl}${url}`, options).then(response => {
     return response.buffer().then(body => {
       ws.send(encodeResponse({
         id,

--- a/src/tunnel.js
+++ b/src/tunnel.js
@@ -28,7 +28,7 @@ if (!localPort) {
 const baseTargetUrl = `http://localhost:${localPort}`;
 
 const parsed_remote = url.parse( remote );
-const uri = `${ parsed_remote.protocol === 'http:' ? 'ws:' : 'wss:' }//${ parsed_remote.hostname }:${ parsed_remote.port || ( parsed_remote.protocol === 'http:' ? 80 : 443 ) }`;
+const uri = `${ parsed_remote.protocol === 'http:' ? 'ws:' : 'wss:' }//${ parsed_remote.hostname || parsed_remote.href }:${ parsed_remote.port || ( parsed_remote.protocol === 'http:' ? 80 : 443 ) }`;
 console.log( `Connecting to ${uri}...` );
 const ws = new WebSocket(uri);
 

--- a/src/tunnel.js
+++ b/src/tunnel.js
@@ -48,13 +48,18 @@ ws.on("message", ev => {
 
   console.log(`> ${method} ${url}`);
 
-  fetch(`${baseTargetUrl}${url}`, {
+  const options = {
     method,
     headers,
-    // Alternately, `Buffer.from(body.slice().buffer)`.
-    body: Buffer.from(body.buffer, body.byteOffset, body.length),
     redirect: "manual"
-  }).then(response => {
+  };
+
+  if ( Buffer.isBuffer( body ) && body.length ) {
+    // Alternately, `Buffer.from(body.slice().buffer)`.
+    options.body = Buffer.from(body.buffer, body.byteOffset, body.length);
+  }
+
+  fetch(`${baseTargetUrl}${url}`, ).then(response => {
     return response.buffer().then(body => {
       ws.send(encodeResponse({
         id,

--- a/src/tunnel.js
+++ b/src/tunnel.js
@@ -16,7 +16,7 @@ const { _: [ remote, localPort ], debug } = yargs
     alias: 'd',
     default: false
   })
-  .usage('tunnel.now [--debug] <remote> <local-port>')
+  .usage('tunnel.now [--debug|-d] <remote> <local-port>')
   .help()
   .argv;
 
@@ -106,12 +106,7 @@ ws.on("message", ev => {
 } );
 });
 
-const keepAliveId = setInterval(() => {
-  ws.send("PING");
-}, 60000);
-
 ws.on("close", () => {
-  clearInterval(keepAliveId);
   console.log("The connection has been terminated.");
 });
 

--- a/src/tunnel.js
+++ b/src/tunnel.js
@@ -2,7 +2,8 @@
 
 const yargs = require("yargs");
 const WebSocket = require("ws");
-const { default: fetch, Headers } = require("node-fetch");
+const fetch = require("node-fetch");
+const url = require( 'url' );
 
 const {
   request: { decode: decodeRequest },
@@ -10,13 +11,13 @@ const {
 } = require("./codec");
 
 
-const { _: [ remoteHostname, localPort ] } = yargs
-  .usage('tunnel.now <remote-hostname> <local-port>')
+const { _: [ remote, localPort ] } = yargs
+  .usage('tunnel.now <remote> <local-port>')
   .help()
   .argv;
 
-if (!remoteHostname) {
-  console.error("You must supply a name for a remote host, listening on port 443.");
+if (!remote) {
+  console.error("You must supply a url for the remote tunnel.");
   process.exit(1);
 }
 if (!localPort) {
@@ -26,22 +27,24 @@ if (!localPort) {
 
 const baseTargetUrl = `http://localhost:${localPort}`;
 
-const uri = `wss://${remoteHostname}:443`;
-const socket = new WebSocket(uri);
+const parsed_remote = url.parse( remote );
+const uri = `${ parsed_remote.protocol === 'http:' ? 'ws:' : 'wss:' }//${ parsed_remote.hostname }:${ parsed_remote.port || ( parsed_remote.protocol === 'http:' ? 80 : 443 ) }`;
+console.log( `Connecting to ${uri}...` );
+const ws = new WebSocket(uri);
 
-socket.addEventListener("open", () => {
+ws.on("open", () => {
   console.log(`Connected to ${uri}.`);
   console.log(`Tunneling requests to ${baseTargetUrl}...`);
 });
 
-socket.addEventListener("message", ev => {
+ws.on("message", ev => {
   const {
     id,
     url,
     method,
     headers,
     body
-  } = decodeRequest(ev.data);
+  } = decodeRequest(ev);
 
   console.log(`> ${method} ${url}`);
 
@@ -53,26 +56,50 @@ socket.addEventListener("message", ev => {
     redirect: "manual"
   }).then(response => {
     return response.buffer().then(body => {
-      socket.send(encodeResponse({
+      ws.send(encodeResponse({
         id,
         statusCode: response.status,
-        headers: response.headers,
+        headers: response.headers.raw(),
         body
       }));
     });
-  });
+  }).catch( error => {
+    if ( error.code === 'ECONNREFUSED' ) {
+        ws.send(encodeResponse({
+          id,
+          statusCode: 503,
+          headers: {
+            'Content-Type': 'application/json'
+          },
+          body: Buffer.from( JSON.stringify( {
+            error: 'Connection refused by tunneled host.'
+          } ) )
+        }));
+        return;
+    }
+
+    ws.send(encodeResponse({
+      id,
+      statusCode: 500,
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: Buffer.from( JSON.stringify( error ) )
+    }));
+} );
 });
 
 const keepAliveId = setInterval(() => {
-  socket.send("PING");
+  ws.send("PING");
 }, 60000);
 
-socket.addEventListener("close", () => {
+ws.on("close", () => {
   clearInterval(keepAliveId);
   console.log("The connection has been terminated.");
 });
 
-socket.addEventListener("error", ev => {
+ws.on("error", ev => {
+  console.dir(ev);
   if (ev.code === "ECONNREFUSED") {
     console.log("We were unable to establish a connection with the server.");
   } else {

--- a/src/tunnel.js
+++ b/src/tunnel.js
@@ -47,6 +47,11 @@ ws.on("message", ev => {
   } = decodeRequest(ev);
 
   console.log(`> ${method} ${url}`);
+  console.log(`> headers: ` );
+  console.dir( headers );
+  console.log( `>` );
+  console.log( `> body:` );
+  console.log( Buffer.isBuffer( body ) && body.length ? body.toString() : '<none>' );
 
   const options = {
     method,

--- a/src/tunnel.js
+++ b/src/tunnel.js
@@ -11,8 +11,12 @@ const {
 } = require("./codec");
 
 
-const { _: [ remote, localPort ] } = yargs
-  .usage('tunnel.now <remote> <local-port>')
+const { _: [ remote, localPort ], debug } = yargs
+  .option('debug', {
+    alias: 'd',
+    default: false
+  })
+  .usage('tunnel.now [--debug] <remote> <local-port>')
   .help()
   .argv;
 
@@ -47,11 +51,14 @@ ws.on("message", ev => {
   } = decodeRequest(ev);
 
   console.log(`> ${method} ${url}`);
-  console.log(`> headers: ` );
-  console.dir( headers );
-  console.log( `>` );
-  console.log( `> body:` );
-  console.log( Buffer.isBuffer( body ) && body.length ? body.toString() : '<none>' );
+
+  if( debug ) {
+    console.log(`> headers: ` );
+    console.dir( headers );
+    console.log( `>` );
+    console.log( `> body:` );
+    console.log( Buffer.isBuffer( body ) && body.length ? body.toString() : '<none>' );
+  }
 
   const options = {
     method,


### PR DESCRIPTION
There are a few changes here:

1) Update npm modules to address an npm audit warning about a DoS in WebSocket

Required some API changes to handle backwards compat issues w/ WebSocket.

2) Allow specifying a remote url instead of just a remote host

This allows someone to do, for example, local testing by running:

```sh
tunnel.now http://localhost:8008 8000
```

Whereas before, the tunnel server had to be listening on now (https/443) you can now point to it listening anywhere if you wish. In the case were a pure hostname is used (eg ```foo.now.sh```) it will work as it used to.

3) There were a couple of error conditions that this tries to handle better:

a) When there is no active connection, we should reply with a 503 and then stop trying to process that request.

b) Sometimes, even when we had a connection, we may no longer be able to reach the forwarded server. In that case, catch fetch() errors and reply with an appropriate response/code.